### PR TITLE
Return keycode when fetching user data

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -1,6 +1,7 @@
 exports.userSafeFields = [
   'uid',
   'email',
+  'keycode',
   'name',
   'role',
   'company',


### PR DESCRIPTION
Add keycode field to the list of returned fields when someone makes a GET /profile/me request.
This change was made since we want mentors to be able to customise how the users find them.

This is ready for review and for terms of brevity I'll rebase and merge this now.