### PR TITLE
fix: /:keycode route was overriding other routes

### DIFF
--- a/routes/mentor.js
+++ b/routes/mentor.js
@@ -4,10 +4,6 @@ const router = express.Router()
 let app, services;
 
 function setRouters() {
-  router.get('/:keycode', (req, res, next) => {
-    services.mentor.get(req, res, next)
-  })
-  
   router.get('/random', (req, res) => {
     services.mentor.getRandom(req, res)
   })
@@ -22,6 +18,10 @@ function setRouters() {
   
   router.get('/verify', (req, res) => {
     services.mentor.verify(req, res)
+  })
+
+  router.get('/:keycode', (req, res, next) => {
+    services.mentor.get(req, res, next)
   })
 }
 

--- a/services/mentor.js
+++ b/services/mentor.js
@@ -10,11 +10,6 @@ class Mentor {
   }
 
   async get(req, res, next) {
-    if(req.params.keycode === 'random' || req.params.keycode === 'slots') {
-      next()
-      return;
-    }
-
     let sql = 'SELECT name, role, company, location, tags, bio, freeSlots, profilePic, twitter, linkedin, github, facebook, dribbble, favoritePlaces FROM users WHERE keycode = ? AND type = "mentor"',
       response = {
         ok: 1,

--- a/services/mentor.js
+++ b/services/mentor.js
@@ -9,7 +9,7 @@ class Mentor {
     if(this.logger) this.logger.verbose('Mentor service loaded')
   }
 
-  async get(req, res, next) {
+  async get(req, res) {
     let sql = 'SELECT name, role, company, location, tags, bio, freeSlots, profilePic, twitter, linkedin, github, facebook, dribbble, favoritePlaces FROM users WHERE keycode = ? AND type = "mentor"',
       response = {
         ok: 1,


### PR DESCRIPTION
It had to do with the wildcard and a wrong middleware parsing method. We just switched it to the bottom (easy fix)