### PR TITLE
Time dates recursive generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "formidable": "^1.2.1",
     "jsonwebtoken": "^8.3.0",
     "mailgun-js": "^0.21.0",
+    "moment": "^2.22.2",
     "morgan": "^1.9.1",
     "mysql2": "^1.6.1",
     "nodemon": "^1.18.4",

--- a/utils/calendar.js
+++ b/utils/calendar.js
@@ -1,0 +1,34 @@
+/**
+ * @description Generates daily slots/events until the date specified or
+ * the number specified of daily events
+ * @param {Object} slot 
+ * @param {Date} until 
+ */
+
+function genDaily(slot, until) {
+  let i = 0
+  
+  // get number of days until which to generate daily slots/events
+  if(typeof until == 'string') i = Math.ceil((new Date(until) - Date.now()) / 864e5)
+  else i = Math.round((new Date(Date.now() + until * 864e5) - slot.start) / 864e5)
+
+  let slotsArr = [],
+    day = new Date(new Date(slot.start).setDate(slot.start.getDate() + i))
+
+  // create slots/events from the last to the first
+  while(i >= 0) {
+    let newSlot = Object.assign({}, slot)
+
+    // set start and end day
+    newSlot.start = new Date(day)
+    newSlot.end = new Date(day)
+    slotsArr.push(newSlot)
+
+    day = new Date(new Date(slot.start).setDate(slot.start.getDate() + --i))
+  }
+
+  return slotsArr
+}
+
+
+module.exports.generateDailySlot = genDaily;

--- a/utils/calendar.js
+++ b/utils/calendar.js
@@ -7,10 +7,10 @@
 
 function genDaily(slot, until) {
   let i = 0
-  
+
   // get number of days until which to generate daily slots/events
   if(typeof until == 'string') i = Math.ceil((new Date(until) - Date.now()) / 864e5)
-  else i = Math.round((new Date(Date.now() + until * 864e5) - slot.start) / 864e5)
+  else i = until
 
   let slotsArr = [],
     day = new Date(new Date(slot.start).setDate(slot.start.getDate() + i))
@@ -30,5 +30,29 @@ function genDaily(slot, until) {
   return slotsArr
 }
 
+function genWeekly(slot, until) {
+  let i = 0
+
+  if(typeof until == 'string') i = Math.floor((new Date(until) - Date.now()) / 864e5 / 7)
+  else i = until
+
+  let slotsArr = []
+    day = new Date(new Date(slot.start).setDate(slot.start.getDate() + i*7))
+  
+  // create slots/events from the last to the first
+  while(i >= 0) {
+    let newSlot = Object.assign({}, slot)
+
+    newSlot.start = new Date(day)
+    newSlot.end = new Date(day)
+    slotsArr.push(newSlot)
+
+    day = new Date(new Date(slot.start).setDate(slot.start.getDate() + (--i)*7))
+  }
+
+  return slotsArr
+}
+
 
 module.exports.generateDailySlot = genDaily;
+module.exports.generateWeeklySlot = genWeekly;

--- a/utils/calendar.js
+++ b/utils/calendar.js
@@ -79,12 +79,12 @@ function automaticGenerate(slots, limitDate) {
 
   for(let slot of slots) {
     switch (slot.recurrency) {
-      case 'Daily':
-        arr = arr.concat(genDaily(slot, new Date(limitDate)))      
-        break;
-      case 'Weekly':
-        arr = arr.concat(genWeekly(slot, new Date(limitDate)))
-        break;
+    case 'Daily':
+      arr = arr.concat(genDaily(slot, new Date(limitDate)))      
+      break;
+    case 'Weekly':
+      arr = arr.concat(genWeekly(slot, new Date(limitDate)))
+      break;
     }
   }
 

--- a/utils/calendar.js
+++ b/utils/calendar.js
@@ -10,9 +10,7 @@ function dateDiff(eventStart, maxDate, diffUnit) {
 
   try {
     if(maxDate instanceof Date) {
-      if(new Date(eventStart).getDate() != new Date(maxDate).getDate()) {
-        num = Math.abs(moment(maxDate).diff(moment(eventStart), diffUnit)) + 1
-      }
+      num = Math.abs(moment(maxDate).diff(moment(eventStart), diffUnit))
     } else if (typeof maxDate == 'number') {
       num = maxDate
     } else throw 'Invalid maximum date'
@@ -74,6 +72,23 @@ function genWeekly(slot, end) {
   return arr
 }
 
+function genMonthly(slot, end) {
+  let num = dateDiff(slot.start, new Date(end), 'M'),
+    i = 0,
+    arr = []
+
+  while(i <= num) {
+    let newSlot = Object.assign({}, slot)
+    newSlot.start = moment(slot.start).add(i, 'M').toDate()
+    newSlot.end = moment(slot.end).add(i, 'M').toDate()
+
+    arr.push(newSlot)
+    i++
+  }
+  return arr
+}
+
+
 function automaticGenerate(slots, limitDate) {
   let arr = [];
 
@@ -84,6 +99,9 @@ function automaticGenerate(slots, limitDate) {
       break;
     case 'Weekly':
       arr = arr.concat(genWeekly(slot, new Date(limitDate)))
+      break;
+    case 'Monthly':
+      arr = arr.concat(genMonthly(slot, new Date(limitDate)))
       break;
     }
   }

--- a/utils/calendar.js
+++ b/utils/calendar.js
@@ -95,13 +95,13 @@ function automaticGenerate(slots, limitDate) {
   for(let slot of slots) {
     switch (slot.recurrency) {
     case 'Daily':
-      arr = arr.concat(genDaily(slot, new Date(limitDate)))      
+      arr = arr.concat(genDaily(slot, limitDate))      
       break;
     case 'Weekly':
-      arr = arr.concat(genWeekly(slot, new Date(limitDate)))
+      arr = arr.concat(genWeekly(slot, limitDate))
       break;
     case 'Monthly':
-      arr = arr.concat(genMonthly(slot, new Date(limitDate)))
+      arr = arr.concat(genMonthly(slot, limitDate))
       break;
     }
   }

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,7 @@
+const calendar = require('./calendar')
 const logger = require('./logs')
 const sql = require('./sql')
 
+module.exports.calendar = calendar
 module.exports.logger = logger
-module.exports.sql = sql;
+module.exports.sql = sql

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,6 +1970,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 morgan@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"


### PR DESCRIPTION
Implemented a new util: calendar util.

Generates events according to their recurrency until the date specified.

Specifics:
- The date specified **MUST** be a valid Date string
- The date hours, minutes and seconds default value is 0 ("2018-11-07" would be transformed to "2018-11-07 00:00:00")
- Only days, weeks and months are supported as of 7th Nov 2018.

This is ready for review.